### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysmon"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Insanitybit <insanitybit@gmail.com>"]
 description = "Type definitions and (de)serialization support for Sysmon events"
 license = "MIT OR Apache-2.0"
@@ -13,11 +13,11 @@ readme = "README.md"
 [dependencies]
 
 
-failure = "0.1.3"
-serde-xml-rs = "0.3.1"
-serde = "1.0.101"
-serde_derive = "1.0.101"
-derive_is_enum_variant = "0.1.1"
-anyhow = "1.0.13"
-chrono = "0.4.9"
-uuid = { version = "0.7", features = ["serde", "v4"] }
+failure = "0.1"
+serde-xml-rs = "0.4"
+serde = "1.0"
+serde_derive = "1.0"
+derive_is_enum_variant = "0.1"
+anyhow = "1"
+chrono = "0.4"
+uuid = { version = "0", features = ["serde", "v4"] }


### PR DESCRIPTION
This updates the Rust dependencies to recent versions. It was inspired by duplicate dependencies found in grapl, which is a user of this crate. It does not intend to match 1:1 all the dependencies found in grapl, but the update alone should reduce duplicates for grapl and other users of this library.